### PR TITLE
Require json in action.rb

### DIFF
--- a/action/action.rb
+++ b/action/action.rb
@@ -1,4 +1,5 @@
 require "ostruct"
+require "json"
 
 require_relative "./install_gems"
 

--- a/autofix/action.yml
+++ b/autofix/action.yml
@@ -3,7 +3,7 @@ description: "Run stree, commit any changes, and add formatting commit to .git-b
 runs:
   using: "composite"
   steps:
-    - uses: planningcenter/balto-syntax_tree@v1
+    - uses: planningcenter/balto-syntax_tree@halloffame-patch-1
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: balto-syntax_tree-commit
       with:

--- a/autofix/action.yml
+++ b/autofix/action.yml
@@ -3,7 +3,7 @@ description: "Run stree, commit any changes, and add formatting commit to .git-b
 runs:
   using: "composite"
   steps:
-    - uses: planningcenter/balto-syntax_tree@halloffame-patch-1
+    - uses: planningcenter/balto-syntax_tree@v1
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: balto-syntax_tree-commit
       with:


### PR DESCRIPTION
We are getting build errors in church-center from this file because JSON is used but not required.

```
uninitialized constant JSON (NameError)

event = JSON.parse(
        ^^^^
/home/runner/work/_actions/planningcenter/balto-syntax_tree/v1/node_modules/@actions/exec/lib/toolrunner.js:59
```

https://github.com/planningcenter/church-center/actions/runs/5391512701/jobs/9788540581?pr=1860