### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.0.2] - 2023-06-29
+
+- Create CODEOWNERS (#1)
+- Require json in action.rb (#2)
+
 ## [1.0.1] - 2022-08-25
 
 - Fix stree command when using smart gem install (default)

--- a/autofix/action.yml
+++ b/autofix/action.yml
@@ -3,7 +3,7 @@ description: "Run stree, commit any changes, and add formatting commit to .git-b
 runs:
   using: "composite"
   steps:
-    - uses: planningcenter/balto-syntax_tree@v1
+    - uses: planningcenter/balto-syntax_tree@v1.0.2
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: balto-syntax_tree-commit
       with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "balto-syntax_tree",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "description": "",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
### Changelog

- #1
- #2

### Note

Having to bump [line 6](https://github.com/planningcenter/balto-syntax_tree/compare/rh/bump-version-1.0.2?expand=1#diff-36852a68a9e4d5ef2960b78624c332e381be9c5a9770734de4ca8ffb606697acR6) every time in `autofix/action.yml` is not ideal.

At some point we should figure out if there is a way to reference actions locally with relative paths. I tried googling but didn't find an obvious answer. So this will do for now.